### PR TITLE
Fix critical & high security issues: auth guards, PHI URL params, ses…

### DIFF
--- a/MVP_FRONTEND_AUDIT.md
+++ b/MVP_FRONTEND_AUDIT.md
@@ -1,0 +1,186 @@
+# DermAtlas Frontend Audit Report
+**Date:** 2026-04-02  
+**Scope:** `client/` — all app routes, services, components, hooks, and state  
+**Reference docs:** `docs/ENDPOINTS.md`, `docs/ENVIRONMENTS.md`, `client/derm_atlas_coding_style.md`
+
+---
+
+## Executive Summary
+
+The UI is well-structured and visually polished, but several **critical security and HIPAA gaps** must be closed before an MVP demo to clinical stakeholders. The most urgent problems are the complete absence of route-level authentication guards and role-based access control, PHI leaking into URL query parameters, and a JWT role fallback that defaults to the most-privileged role. These are fixable in a focused sprint.
+
+---
+
+## Severity Legend
+
+| Severity | Meaning |
+|---|---|
+| 🔴 CRITICAL | Demo-blocking; exploitable by any end user with a URL |
+| 🟠 HIGH | Significant HIPAA / security concern or functional breakage |
+| 🟡 MEDIUM | Important to address before production; acceptable for a controlled demo |
+| 🔵 LOW | Polish, dead code, style violations |
+
+---
+
+## Checklist
+
+### 🔴 CRITICAL
+
+- [ ] **C-1 — No route guards in `_layout.tsx`**  
+  `app/_layout.tsx` contains **zero authentication logic**. Any user who navigates directly to `/upload`, `/compare`, `/admin/users`, or `/admin/audit-logs` (e.g. by typing the URL or using browser back/forward) can access those screens without logging in. Expo Router's recommended pattern (`useSegments` + `useRootNavigationState` redirect) is entirely absent. A protected `<Stack>` or a root redirect effect keyed on `useAuthStore` token is required.
+
+- [ ] **C-2 — Admin routes have no role guard**  
+  `app/admin/users.tsx` and `app/admin/audit-logs.tsx` perform **no check** on whether the current user holds the `PCP` role. The only gating is that the navigation buttons are hidden on `profile.tsx` — but a `PATIENT` user who types `/admin/users` directly sees the full user-management UI. The API will (hopefully) return 403, but the page shell renders and shows the loading spinner first. Each admin screen must check `user?.role` on mount and redirect non-PCP users.
+
+- [ ] **C-3 — JWT role fallback defaults to most-privileged role**  
+  In `services/auth-service.ts:46`:
+  ```ts
+  role: ((payload.role as UserRole) ?? "PCP"),
+  ```
+  If the JWT contains no `role` claim, the user is silently elevated to `PCP` (which also grants access to "Administrator Controls" on the Profile screen). The fallback must be `"PATIENT"` (least-privileged) or throw a hard error requiring re-authentication.
+
+- [ ] **C-4 — PHI transmitted via URL query parameters**  
+  `upload.tsx:52` and `compare.tsx:139` pass **patient name, MRN, diagnosis labels, and image URIs** as URL search parameters:
+  ```
+  /compare?patientId=…&patientMrn=MRN-001&patientName=Alice+Johnson&…
+  /feedback?diagnosis=Basal+cell+carcinoma&referenceImageUri=https://storage.googleapis.com/…
+  ```
+  These values appear in:
+  - browser/device history
+  - server access logs
+  - analytics and crash-reporting tools
+  
+  Under HIPAA, names and MRNs are direct identifiers (45 CFR §164.514(b)(2)). Passing them in URLs violates the minimum-necessary and de-identification standards. Pass only opaque IDs (e.g. `queryId`, `patientId`) and look up display values on the destination screen from the store or a service call.
+
+---
+
+### 🟠 HIGH
+
+- [ ] **H-1 — No automatic session timeout (HIPAA §164.312(a)(2)(iii))**  
+  There is no idle timer, no token-expiry countdown, and no automatic logout after inactivity. HIPAA's Technical Safeguards require an "automatic logoff" mechanism for workstations. A configurable inactivity timer (commonly 15–30 minutes for clinical tools) that calls `clearAuth()` and redirects to `/` is required for any deployment in a clinical environment.
+
+- [ ] **H-2 — 401 responses do not trigger re-authentication**  
+  `services/http.ts:20` throws a generic `Error` on any non-OK response, including `401`. No screen catches `401` to call `clearAuth()` and redirect to login. When a JWT expires mid-session, users see a raw error banner ("Request failed (401)") rather than being sent back to the login screen. A global 401 handler in `apiFetch` should call `clearAuth()` and `router.replace("/")`.
+
+- [ ] **H-3 — Auth state is not persisted across web refreshes**  
+  `state/auth-store.ts` uses plain Zustand with **no persistence adapter**. On web, a page refresh silently destroys the token. If the user was on `/upload` and refreshes, there is no auth guard to redirect them (see C-1), so they see authenticated UI with no credentials — every API call will 401. Even without a full persistence solution, the missing guard makes this actively broken.
+
+- [ ] **H-4 — Upload and My-Cases screens have no role guard**  
+  `app/upload.tsx` has no check that `user?.role === "PCP"`. A patient navigating to `/upload` sees the full clinician upload form. Conversely, `app/my-cases.tsx` has no check that `user?.role === "PATIENT"` — a PCP navigating there would see the patient view. Each screen should redirect to the appropriate home route if the role is wrong.
+
+---
+
+### 🟡 MEDIUM
+
+- [ ] **M-1 — Role display in `profile.tsx` conflates PCP with Admin**  
+  `app/profile.tsx:25`:
+  ```ts
+  const displayRole = user?.role === "PCP" ? "PCP, Admin" : user?.role ?? "—";
+  ```
+  All PCPs are labeled "PCP, Admin" in the profile card. This is inaccurate if not all PCPs are intended to be system administrators. It also leaks the internal privilege model to users. Either introduce a distinct `ADMIN` role or display it as "PCP" and separately indicate admin access where relevant.
+
+- [ ] **M-2 — Patient list fetched entirely to client in `PatientSelector`**  
+  `components/patient-selector.tsx` calls `getPatients()` which retrieves **all patients** from the API (including name, MRN, DOB, gender) into client memory, then filters locally. For a small MVP demo this is fine, but it violates HIPAA's minimum-necessary principle: a clinician looking to attach one patient record receives every patient's PHI. The endpoint should accept a search query parameter so only matching results are returned.
+
+- [ ] **M-3 — GCS image URIs are passed and loaded directly without signed-URL validation**  
+  `gcs_uri` values from the API are passed directly to `<Image source={{ uri: gcs_uri }} />`. If these are publicly accessible GCS URLs (not signed), they can be shared, bookmarked, and accessed indefinitely by anyone with the link — bypassing any access control. The backend should return short-lived signed URLs, or images should be proxied through the authenticated API.
+
+- [ ] **M-4 — `showMobileActions` builds an unused `options` array**  
+  `app/admin/users.tsx:106–110`:
+  ```ts
+  const options: string[] = ["Edit"];
+  if (user.is_active) options.push("Deactivate");
+  options.push("Cancel");
+  // `options` is never referenced below — Alert.alert is hardcoded
+  ```
+  Dead code that will cause a lint warning. Remove the `options` variable.
+
+- [ ] **M-5 — Error status detection via string-matching in `audit-service.ts`**  
+  `services/audit-service.ts:208–213` checks `message.includes("401")` and `message.includes("403")` to detect HTTP statuses. This is fragile: it depends on the exact error string format from `http.ts` ("Request failed (401)"). A dedicated error type or numeric status code on the thrown error is cleaner and more reliable.
+
+- [ ] **M-6 — `use-image-capture.web.ts` leaks object URLs**  
+  `hooks/use-image-capture.web.ts:13,22` calls `URL.createObjectURL(file)` and never calls `URL.revokeObjectURL`. Each time the user picks an image on web, a blob URL is retained in memory for the lifetime of the page. Long clinical sessions with multiple image selections will accumulate leaks.
+
+---
+
+### 🔵 LOW / Style
+
+- [ ] **L-1 — "Forgot Password?" button is a no-op**  
+  `app/index.tsx:158`:
+  ```tsx
+  <Pressable onPress={() => {}} style={styles.forgotWrap}>
+  ```
+  Visible, tappable UI element that does nothing. Either implement a password-reset flow or remove the button before the demo to avoid confusion and questions.
+
+- [ ] **L-2 — Thumb-vote buttons on Compare screen are no-ops**  
+  `app/compare.tsx:201–211` renders thumb-up/thumb-down buttons inside each `MatchCard` with `onPress={() => {}}`. These look interactive but silently do nothing. The real feedback is on the `/feedback` route. These stub buttons should be removed or wired up.
+
+- [ ] **L-3 — `CaseCard` `Pressable` has no `onPress`**  
+  `app/my-cases.tsx:171`:
+  ```tsx
+  <Pressable style={...}>
+  ```
+  The pressable renders with a visual press-state but no handler. Patients see a list of cases with no way to interact with them. Either add navigation to a case-detail screen or render a `View` instead of `Pressable` to avoid false affordance.
+
+- [ ] **L-4 — `app/modal.tsx` is an unimplemented scaffold**  
+  The file contains the default Expo "This is a modal" boilerplate. It is registered as a route and accessible. It should be removed from the router or replaced with a real implementation.
+
+- [ ] **L-5 — Route files contain large sub-components (style guide §4, §14.3)**  
+  Per `derm_atlas_coding_style.md` §4, route files should "orchestrate components/hooks, not contain heavy business logic." Currently:
+  - `app/compare.tsx` defines `MatchCard`, `SimilarityBar`, `SimilarityBadge` inline.
+  - `app/profile.tsx` defines `MenuRow` and `SectionHeader` inline.
+  
+  These should be extracted to `components/` before the codebase grows further.
+
+- [ ] **L-6 — `constants/demo-images.ts` not listed in documented directory structure**  
+  The coding style guide's directory structure (§3) lists only `theme.ts` under `constants/`. `demo-images.ts` is an undocumented addition. Not a functional issue, but worth noting in the style guide for consistency.
+
+- [ ] **L-7 — `auth-service.ts` mock mode uses email heuristic for role assignment**  
+  `services/auth-service.ts:21`:
+  ```ts
+  const mockRole: UserRole = email.toLowerCase().includes("patient") ? "PATIENT" : "PCP";
+  ```
+  This works for demos but is easy to forget. The mock token string `"mock-token"` is also treated as valid by any part of the app that reads the token — ensure nothing is checking token format in places that would fail with a mock.
+
+---
+
+## Summary Table
+
+| ID | File(s) | Description | Severity |
+|---|---|---|---|
+| C-1 | `app/_layout.tsx` | No auth guard — all routes accessible without login | 🔴 CRITICAL |
+| C-2 | `app/admin/users.tsx`, `app/admin/audit-logs.tsx` | Admin routes have no role check | 🔴 CRITICAL |
+| C-3 | `services/auth-service.ts:46` | JWT role defaults to `"PCP"` (most-privileged) | 🔴 CRITICAL |
+| C-4 | `app/upload.tsx:52`, `app/compare.tsx:139` | PHI (name, MRN, diagnosis) in URL query params | 🔴 CRITICAL |
+| H-1 | `state/auth-store.ts` | No automatic session timeout / idle logout | 🟠 HIGH |
+| H-2 | `services/http.ts:20` | 401 responses do not trigger re-login | 🟠 HIGH |
+| H-3 | `state/auth-store.ts` | Auth state lost on web page refresh, no guard catches it | 🟠 HIGH |
+| H-4 | `app/upload.tsx`, `app/my-cases.tsx` | No role guard on role-specific screens | 🟠 HIGH |
+| M-1 | `app/profile.tsx:25` | All PCPs display as "PCP, Admin" incorrectly | 🟡 MEDIUM |
+| M-2 | `components/patient-selector.tsx` | All patients' PHI fetched to client; no server-side search | 🟡 MEDIUM |
+| M-3 | `services/patient-service.ts`, `app/my-cases.tsx` | GCS URIs loaded directly without signed-URL access control | 🟡 MEDIUM |
+| M-4 | `app/admin/users.tsx:106` | Dead `options` array never used | 🟡 MEDIUM |
+| M-5 | `services/audit-service.ts:208` | HTTP status detected via fragile string-matching | 🟡 MEDIUM |
+| M-6 | `hooks/use-image-capture.web.ts:13,22` | `URL.createObjectURL` never revoked — memory leak | 🟡 MEDIUM |
+| L-1 | `app/index.tsx:158` | "Forgot Password?" is a no-op button | 🔵 LOW |
+| L-2 | `app/compare.tsx:201–211` | Thumb-vote buttons are no-ops | 🔵 LOW |
+| L-3 | `app/my-cases.tsx:171` | `CaseCard` `Pressable` has no `onPress` | 🔵 LOW |
+| L-4 | `app/modal.tsx` | Unimplemented scaffold route still present | 🔵 LOW |
+| L-5 | `app/compare.tsx`, `app/profile.tsx` | Large sub-components defined inside route files | 🔵 LOW |
+| L-6 | `constants/demo-images.ts` | Not documented in coding style directory structure | 🔵 LOW |
+| L-7 | `services/auth-service.ts:21` | Mock mode derives role from email heuristic | 🔵 LOW |
+
+---
+
+## MVP Demo Priority
+
+To be safe for a **controlled clinical demo** (internal, to authorized stakeholders), the absolute minimum fixes are:
+
+1. **C-1** — Add an auth guard so unauthenticated URL access redirects to login.
+2. **C-2** — Add role checks to admin routes (redirect PATIENT users away).
+3. **C-3** — Change JWT role fallback from `"PCP"` to `"PATIENT"`.
+4. **C-4** — Strip PHI from URL parameters (pass only IDs; resolve display values on destination screen).
+5. **H-4** — Add role guards to `/upload` and `/my-cases`.
+6. **L-1, L-2, L-3** — Remove non-functional interactive elements before demo to avoid questions.
+
+Issues H-1 through H-3 and M-1 through M-6 should be addressed before any demo that involves real patient data or clinical staff outside a controlled setting.

--- a/MVP_STRATEGY.md
+++ b/MVP_STRATEGY.md
@@ -1,0 +1,228 @@
+# DermAtlas MVP Gap Analysis & Strategy
+
+> Generated 2026-03-31 after full codebase audit of `client/`.
+> Scope: React Native / Expo frontend only. Backend endpoints assumed functional where services already call them.
+
+---
+
+## Part 1: What Actually Works (Baseline)
+
+Before listing gaps, here is what is end-to-end functional with the real API today:
+
+| Flow | Status |
+|------|--------|
+| Login with username/password → JWT stored in Zustand | ✓ Working |
+| Camera permission + `launchCameraAsync` → image preview | ✓ Working (native only — see §2.1) |
+| Photo library picker → image preview | ✓ Working |
+| Blob conversion + multipart POST /upload/image | ✓ Working |
+| POST /lesion/analyze → similarity match grid | ✓ Working |
+| Click match card → feedback screen with comparison modal | ✓ Working |
+| Synchronized pan/zoom comparison modal | ✓ Working |
+| Feedback vote (helpful/not helpful) → POST /feedback | ✓ Working |
+| Logout → clears auth store → back to login | ✓ Working |
+| Profile page loads user info from store | ✓ Working (display only) |
+
+**Core clinical workflow is functional.** Everything else described below is broken, stubbed, or missing.
+
+---
+
+## Part 2: Blockers to MVP Status
+
+### 2.1 Camera Doesn't Work on Web
+
+**Problem:** `expo-image-picker`'s `launchCameraAsync` on web does not open a live camera view — it falls back silently to the file picker or does nothing, depending on the browser. The app targets web as a delivery platform (app.json: `"output": "static"`), so PCPs using a browser can never use the camera button.
+
+**Root cause:** `pickFromCamera` in `upload.tsx:34–47` calls `ImagePicker.launchCameraAsync` without a platform guard. Web camera capture requires either `<input capture="environment">` HTML or the `MediaDevices.getUserMedia` API — neither of which expo-image-picker wires up on web automatically.
+
+**Fix strategy:**
+- Add a web-specific implementation using `<input type="file" accept="image/*" capture="environment" />` wrapped in a hidden ref — trigger it programmatically on the Camera button press.
+- Gate with `Platform.OS === 'web'` to keep native path intact.
+- File: `upload.tsx` or extract a `hooks/use-image-capture.ts` that returns the right handler per platform.
+
+---
+
+### 2.2 No PCP Patient List / Patient Dropdown
+
+**Problem:** The upload screen has a free-text numeric "Patient ID" field. There is no way to browse or select a patient from the PCP's care list. The `patient-service.ts` file is defined (`getPatient`) but is **never imported or called anywhere in the app.**
+
+**Root cause:** The patient management layer was never connected to the UI.
+
+**Additional bug in existing code:** `parseInt(patientId) || 0` in `upload.tsx:73` sends `0` to the backend when the field is blank. This is a silent data integrity issue — uploads get orphaned to patient 0.
+
+**Fix strategy:**
+- Add a `GET /patients` (list) endpoint call or use repeated `getPatient` calls with known IDs (backend-dependent).
+- Build a patient selector: either a `SearchableDropdown` component triggered by the Patient ID field (autocomplete) or a dedicated `/patients` route listing the PCP's patients.
+- Wire the selected patient's `patient_id` (integer) directly into the upload call, removing the free-text field.
+- Validate that patientId is non-empty before enabling the Submit button.
+
+---
+
+### 2.3 All Profile Page Actions Are No-Ops
+
+**Problem:** All three action rows in `profile.tsx` call `Alert.alert("...not yet available in this version.")`. There is no navigation, no API call, and no UI flow behind any of them.
+
+| Button | Handler | Real behavior |
+|--------|---------|---------------|
+| Change Password | `handleChangePassword` | Alert only |
+| Manage Users | `handleManageUsers` | Alert only |
+| View Audit Logs | `handleAuditLogs` | Alert only |
+
+**Fix strategy per item:**
+- **Change Password:** Navigate to a new `app/change-password.tsx` screen with current password + new password fields → `PATCH /auth/password` or similar.
+- **Manage Users:** Navigate to `app/admin/users.tsx` — a list of users with Add/Edit/Deactivate actions. Requires a `GET /users` + `POST /users` + `DELETE /users/{id}` API surface. If the backend doesn't expose this yet, stub a read-only list first.
+- **View Audit Logs:** Navigate to `app/admin/audit-logs.tsx` — paginated list from `GET /audit-logs`. If backend doesn't expose this, defer but remove the menu row rather than leave a dead tap target.
+
+---
+
+### 2.4 No User Selector / Role Switching
+
+**Problem:** The login page accepts any username/password but there is no dropdown to select from known users. In a demo or multi-user context, every session requires typing credentials from scratch. More critically, `auth-service.ts:41` hardcodes the role as `"PCP"` for all real API logins regardless of what the backend returns — there is no patient role path.
+
+```ts
+// auth-service.ts line ~41 (real API path)
+const user: UserInfo = {
+  userId: ...,
+  email: ...,
+  fullName: ...,
+  role: "PCP",  // ← hardcoded; backend role ignored
+};
+```
+
+**Fix strategy:**
+- Add a "Quick Login" or "Select User" dropdown on the login screen populated from a hardcoded list of demo accounts (or fetched from `GET /users`). This is valuable for demos and testing.
+- Fix `auth-service.ts` to read the role from the API response (requires the backend to return it in the token response or a `/auth/me` endpoint).
+- Implement the `PATIENT` role path: the `UserRole` type already defines it, but no UI differentiation exists.
+
+---
+
+### 2.5 Auth State Is Not Persisted
+
+**Problem:** `state/auth-store.ts` uses a plain Zustand store with no persistence. Reloading the web app or backgrounding the native app clears the token and redirects to login.
+
+**Fix strategy:**
+- Add `zustand/middleware` `persist` with `AsyncStorage` (native) and `localStorage` (web) as the storage adapter.
+- Wrap the `auth-store` with `persist(...)` — this is a 5-line change.
+- On app startup (`_layout.tsx`), check for a persisted token before rendering routes, and validate it against the backend (or just accept it optimistically).
+
+---
+
+### 2.6 Patient ID Shown as "______" on Compare Screen
+
+**Problem:** `compare.tsx` hardcodes the patient ID display as the string `"______"`. The patient ID is passed as a query parameter (it's in the URL) but it is never read or displayed. A clinician looking at the results has no confirmation of which patient they're analyzing.
+
+**Fix strategy:**
+- Pass `patientId` as a query param when navigating from `upload.tsx` to `/compare`.
+- Read it from `useLocalSearchParams()` in `compare.tsx` and display it in the header strip.
+
+---
+
+### 2.7 Quick-Vote Buttons on Compare Cards Are Stubbed
+
+**Problem:** The thumbs-up / thumbs-down buttons on each match card in `compare.tsx` have `onPress={() => {}}`. These look interactive but do nothing.
+
+**Options:**
+- Wire them to `submitFeedback()` (the same service `feedback.tsx` uses) — makes the quick-vote path functional without navigating away.
+- Or remove the buttons entirely from the card if deep-linking to `feedback.tsx` is the intended primary path.
+- Do not leave silent no-op buttons in a clinical tool.
+
+---
+
+### 2.8 Lesion Location Hardcoded as "unspecified"
+
+**Problem:** `upload.tsx:73` calls `uploadImage(blob, parseInt(patientId) || 0, "unspecified")`. The `lesion_location` field is permanently hardcoded. This is a clinically relevant data field.
+
+**Fix strategy:**
+- Add a location picker to the upload form — a segmented control or dropdown with anatomical regions (face, trunk, limb, etc.).
+- Pass the selected value to `uploadImage`.
+
+---
+
+### 2.9 No Case / Visit History
+
+**Problem:** There is no screen to view a patient's previous submissions. Each session starts at the upload screen with no historical context. The `PatientResponse` type includes a `clinical_images: ClinicalImageSummary[]` array, which implies the backend can return past cases — but nothing in the UI retrieves or displays it.
+
+**Fix strategy:**
+- On the patient selection screen (§2.2), after a patient is selected, fetch `getPatient(id)` and show their past cases below the new-upload form.
+- Or navigate to a patient detail screen `/patients/[id]` that lists prior images + diagnoses with timestamps.
+
+---
+
+### 2.10 No Navigation Guard / Protected Routes
+
+**Problem:** There is no route protection. Navigating directly to `/upload`, `/compare`, or `/profile` without being logged in will crash or render broken UI (user is null, no token).
+
+**Fix strategy:**
+- In `_layout.tsx`, check `useAuthStore` for a token. If absent, redirect to `/` (login).
+- This is a single `useEffect` or conditional render in the layout.
+
+---
+
+## Part 3: Secondary Issues (Below MVP Threshold)
+
+These won't block an MVP demo but would be embarrassing or confusing in front of stakeholders.
+
+| Issue | Location | Notes |
+|-------|----------|-------|
+| `modal.tsx` is a leftover Expo template stub | `app/modal.tsx` | Not linked anywhere; delete or repurpose |
+| `hello-wave.tsx` and `parallax-scroll-view.tsx` unused | `components/` | Template artifacts; no harm but dead weight |
+| Forgot password button is a silent no-op | `index.tsx:158` | Either implement or remove the link |
+| Camera button shows on web with no functional fallback | `upload.tsx` | See §2.1 |
+| `USE_MOCK` toggle requires code change | `services/config.ts` | Not ergonomic for demo switching; add env var or settings UI |
+| No error boundary | `app/_layout.tsx` | A single thrown error crashes the entire app with a white screen |
+| Role always "PCP" even for non-PCP logins | `auth-service.ts` | Backend role ignored |
+| No image size/quality validation before upload | `upload.tsx` | Large or blurry images succeed silently |
+| `patient_id: 0` sent when field is empty | `upload.tsx:73` | Silent data integrity issue |
+| No loading state on compare screen if `queryId` missing | `compare.tsx` | Would crash if navigated to directly |
+
+---
+
+## Part 4: Strategy of Attack (Prioritized)
+
+### Phase 1 — Demo Stability (Before Any External Demo)
+These are the minimum fixes to avoid embarrassing moments or broken-looking flows.
+
+1. **Fix patient ID display on compare screen** — read and show the patient ID from URL params.
+2. **Guard protected routes** — redirect to login if no token.
+3. **Remove or fix the quick-vote stubs on compare cards** — either wire to API or hide.
+4. **Fix patient_id defaulting to 0** — require the field or validate before submit.
+5. **Persist auth state** — use Zustand `persist` so refresh doesn't log users out.
+
+### Phase 2 — Core Missing Features (MVP)
+These are the features the user explicitly called out as missing.
+
+6. **Patient dropdown / selector on upload screen** — wire `patient-service.getPatient` or a list endpoint; replace free-text input.
+7. **Camera on web** — add `Platform.OS === 'web'` branch using `<input capture="environment" />`.
+8. **Lesion location picker** — add anatomical region selector to the upload form.
+9. **User dropdown on login** — quick-select from known demo accounts or fix role from API response.
+10. **Patient history** — after patient selection, show prior cases from `clinical_images[]`.
+
+### Phase 3 — Profile Page Functionality
+These make the profile page not an embarrassment.
+
+11. **Change Password** — new screen + API call.
+12. **Manage Users** — at minimum a read-only list; CRUD if API supports it.
+13. **Audit Logs** — read-only paginated list; defer if backend doesn't expose it yet (but remove the menu row).
+
+### Phase 4 — Quality & Robustness (Post-MVP)
+14. Error boundary in `_layout.tsx`.
+15. Delete template artifacts (`modal.tsx`, `hello-wave.tsx`, `parallax-scroll-view.tsx`).
+16. Implement forgot-password flow or remove the link.
+17. Image size/format validation before upload.
+18. Token expiry detection and automatic re-login prompt.
+
+---
+
+## Part 5: File Change Map
+
+| Feature | Files to touch |
+|---------|----------------|
+| Camera on web (§2.1) | `app/upload.tsx` or new `hooks/use-image-capture.ts` |
+| Patient dropdown (§2.2) | `services/patient-service.ts` (add list fn), new `components/patient-selector.tsx`, `app/upload.tsx` |
+| Profile actions (§2.3) | `app/profile.tsx`, new `app/change-password.tsx`, new `app/admin/users.tsx`, new `app/admin/audit-logs.tsx` |
+| User selector / role fix (§2.4) | `app/index.tsx`, `services/auth-service.ts` |
+| Auth persistence (§2.5) | `state/auth-store.ts` |
+| Patient ID on compare (§2.6) | `app/upload.tsx` (pass param), `app/compare.tsx` (read param) |
+| Quick-vote stubs (§2.7) | `app/compare.tsx` |
+| Lesion location picker (§2.8) | `app/upload.tsx`, `services/upload-service.ts` (already accepts param) |
+| Case history (§2.9) | `services/patient-service.ts`, `app/upload.tsx` or new `app/patients/[id].tsx` |
+| Route protection (§2.10) | `app/_layout.tsx` |

--- a/client/app/_layout.tsx
+++ b/client/app/_layout.tsx
@@ -4,9 +4,13 @@ import { StatusBar } from "expo-status-bar";
 import "react-native-reanimated";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { useColorScheme } from "@/hooks/use-color-scheme";
+import { useProtectedRoute } from "@/hooks/use-protected-route";
+import { useSessionTimeout } from "@/hooks/use-session-timeout";
 
 export default function RootLayout() {
   const colorScheme = useColorScheme();
+  useProtectedRoute();
+  useSessionTimeout();
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>

--- a/client/app/compare.tsx
+++ b/client/app/compare.tsx
@@ -12,6 +12,7 @@ import { useLocalSearchParams, useRouter } from "expo-router";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
 import { Image } from "expo-image";
 import { useAuthStore } from "@/state/auth-store";
+import { useCurrentCaseStore } from "@/state/current-case-store";
 import { useRequireRole } from "@/hooks/use-require-role";
 import { analyzeLesion } from "@/services/lesion-service";
 import { DEMO_IMAGES, DEMO_UPLOAD_IMAGE } from "@/constants/demo-images";
@@ -24,21 +25,17 @@ export default function Compare() {
   const router = useRouter();
   const user = useAuthStore((s) => s.user);
   const clearAuth = useAuthStore((s) => s.clearAuth);
-  const { queryId, imageUri, patientId, patientMrn, patientName } = useLocalSearchParams<{
-    queryId?: string;
-    imageUri?: string;
-    patientId?: string;
-    patientMrn?: string;
-    patientName?: string;
-  }>();
+  const { queryId } = useLocalSearchParams<{ queryId?: string }>();
+  const patientName = useCurrentCaseStore((s) => s.patientName);
+  const patientMrn = useCurrentCaseStore((s) => s.patientMrn);
+  const patientId = useCurrentCaseStore((s) => s.patientId);
+  const imageUri = useCurrentCaseStore((s) => s.imageUri);
+  const setFeedbackTarget = useCurrentCaseStore((s) => s.setFeedbackTarget);
   const [matches, setMatches] = useState<AnalyzeMatch[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const decodedImageUri = imageUri ? decodeURIComponent(imageUri) : null;
-  const decodedPatientName = patientName ? decodeURIComponent(patientName) : "";
-  const decodedPatientMrn = patientMrn ? decodeURIComponent(patientMrn) : "";
-  const patientLabel = decodedPatientName || decodedPatientMrn || (patientId ? `ID # ${patientId}` : "—");
+  const patientLabel = patientName || patientMrn || (patientId ? `ID # ${patientId}` : "—");
 
   useEffect(() => {
     if (!authorized) return;
@@ -100,8 +97,8 @@ export default function Compare() {
             />
             <View style={{ flex: 1 }}>
               <Text style={styles.patientText}>Patient: {patientLabel}</Text>
-              {decodedPatientMrn && decodedPatientName ? (
-                <Text style={styles.patientMeta}>{decodedPatientMrn} · ID #{patientId}</Text>
+              {patientMrn && patientName ? (
+                <Text style={styles.patientMeta}>{patientMrn} · ID #{patientId}</Text>
               ) : patientId ? (
                 <Text style={styles.patientMeta}>ID #{patientId}</Text>
               ) : null}
@@ -113,7 +110,7 @@ export default function Compare() {
             <Text style={styles.sectionLabel}>Submitted Image</Text>
             <View style={styles.imageCard}>
               <Image
-                source={decodedImageUri ? { uri: decodedImageUri } : DEMO_UPLOAD_IMAGE}
+                source={imageUri ? { uri: imageUri } : DEMO_UPLOAD_IMAGE}
                 style={styles.submittedImage}
                 contentFit="cover"
               />
@@ -144,13 +141,16 @@ export default function Compare() {
                 <MatchCard
                   key={m.reference_id}
                   m={m}
-                  queryId={queryId}
-                  decodedImageUri={decodedImageUri}
                   onPress={() => {
                     const similarity = Math.round(m.score * 100);
-                    router.push(
-                      `/feedback?matchId=${m.reference_id}&queryId=${queryId ?? ""}&referenceId=${m.reference_id}&diagnosis=${encodeURIComponent(m.diagnosis_label ?? "")}&similarity=${similarity}&imageUri=${encodeURIComponent(decodedImageUri ?? "")}&referenceImageUri=${encodeURIComponent(m.gcs_uri ?? "")}`
-                    );
+                    setFeedbackTarget({
+                      matchId: m.reference_id,
+                      referenceId: m.reference_id,
+                      diagnosis: m.diagnosis_label ?? "",
+                      similarity,
+                      referenceImageUri: m.gcs_uri ?? "",
+                    });
+                    router.push(`/feedback?matchId=${m.reference_id}&referenceId=${m.reference_id}`);
                   }}
                 />
               ))}
@@ -165,13 +165,9 @@ export default function Compare() {
 
 function MatchCard({
   m,
-  queryId: _queryId,
-  decodedImageUri: _decodedImageUri,
   onPress,
 }: {
   m: AnalyzeMatch;
-  queryId: string | undefined;
-  decodedImageUri: string | null;
   onPress: () => void;
 }) {
   const [imgError, setImgError] = useState(false);

--- a/client/app/feedback.tsx
+++ b/client/app/feedback.tsx
@@ -13,6 +13,7 @@ import { MaterialCommunityIcons } from "@expo/vector-icons";
 import { Image } from "expo-image";
 import { submitFeedback } from "@/services/feedback-service";
 import { useAuthStore } from "@/state/auth-store";
+import { useCurrentCaseStore } from "@/state/current-case-store";
 import { useRequireRole } from "@/hooks/use-require-role";
 import { ComparisonModal } from "@/components/comparison-modal";
 import { DEMO_IMAGES, DEMO_UPLOAD_IMAGE } from "@/constants/demo-images";
@@ -24,23 +25,15 @@ export default function Feedback() {
   const router = useRouter();
   const user = useAuthStore((s) => s.user);
   const clearAuth = useAuthStore((s) => s.clearAuth);
-  const {
-    matchId,
-    queryId,
-    referenceId,
-    diagnosis,
-    similarity,
-    imageUri,
-    referenceImageUri,
-  } = useLocalSearchParams<{
+  const { matchId, referenceId } = useLocalSearchParams<{
     matchId?: string;
-    queryId?: string;
     referenceId?: string;
-    diagnosis?: string;
-    similarity?: string;
-    imageUri?: string;
-    referenceImageUri?: string;
   }>();
+  const queryId = useCurrentCaseStore((s) => s.queryId);
+  const imageUri = useCurrentCaseStore((s) => s.imageUri);
+  const diagnosis = useCurrentCaseStore((s) => s.diagnosis);
+  const similarity = useCurrentCaseStore((s) => s.similarity);
+  const referenceImageUri = useCurrentCaseStore((s) => s.referenceImageUri);
 
   const [vote, setVote] = useState<"up" | "down" | null>(null);
   const [submitting, setSubmitting] = useState(false);
@@ -48,12 +41,10 @@ export default function Feedback() {
 
   if (!authorized) return null;
 
-  const uploadedSource = imageUri
-    ? { uri: decodeURIComponent(imageUri) }
-    : DEMO_UPLOAD_IMAGE;
+  const uploadedSource = imageUri ? { uri: imageUri } : DEMO_UPLOAD_IMAGE;
 
   const referenceSource = referenceImageUri
-    ? { uri: decodeURIComponent(referenceImageUri) }
+    ? { uri: referenceImageUri }
     : (referenceId ? DEMO_IMAGES[referenceId] : undefined);
 
   async function handleVote(direction: "up" | "down") {

--- a/client/app/upload.tsx
+++ b/client/app/upload.tsx
@@ -13,6 +13,7 @@ import { useRouter } from "expo-router";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
 import { Image } from "expo-image";
 import { useAuthStore } from "@/state/auth-store";
+import { useCurrentCaseStore } from "@/state/current-case-store";
 import { useRequireRole } from "@/hooks/use-require-role";
 import { uploadImage } from "@/services/upload-service";
 import { useImageCapture } from "@/hooks/use-image-capture";
@@ -26,6 +27,7 @@ export default function Upload() {
   const router = useRouter();
   const user = useAuthStore((s) => s.user);
   const clearAuth = useAuthStore((s) => s.clearAuth);
+  const setCase = useCurrentCaseStore((s) => s.setCase);
   const [selectedPatient, setSelectedPatient] = useState<PatientResponse | null>(null);
   const [imageUri, setImageUri] = useState<string | null>(null);
   const [uploading, setUploading] = useState(false);
@@ -53,9 +55,14 @@ export default function Upload() {
       const response = await fetch(imageUri);
       const blob = await response.blob();
       const res = await uploadImage(blob, selectedPatient.patient_id, "unspecified");
-      router.push(
-        `/compare?queryId=${encodeURIComponent(res.query_id)}&imageUri=${encodeURIComponent(imageUri)}&patientId=${encodeURIComponent(selectedPatient.patient_id)}&patientMrn=${encodeURIComponent(selectedPatient.mrn_internal)}&patientName=${encodeURIComponent(selectedPatient.full_name ?? "")}`
-      );
+      setCase({
+        patientId: selectedPatient.patient_id,
+        patientMrn: selectedPatient.mrn_internal,
+        patientName: selectedPatient.full_name ?? "",
+        queryId: res.query_id,
+        imageUri,
+      });
+      router.push(`/compare?queryId=${encodeURIComponent(res.query_id)}`);
     } catch (err) {
       Alert.alert("Upload failed", err instanceof Error ? err.message : "Please try again.");
     } finally {

--- a/client/hooks/use-protected-route.ts
+++ b/client/hooks/use-protected-route.ts
@@ -1,0 +1,53 @@
+import { useEffect } from "react";
+import { useSegments, useRootNavigationState, useRouter } from "expo-router";
+import { useAuthStore } from "@/state/auth-store";
+
+const PCP_ONLY: string[] = ["upload", "compare", "feedback", "admin"];
+const PATIENT_ONLY: string[] = ["my-cases"];
+
+/**
+ * Global auth + role guard. Call once from the root layout.
+ * - Unauthenticated users are redirected to "/" for any protected route.
+ * - Authenticated users on the login screen are redirected to their home.
+ * - PATIENT users are bounced away from PCP-only routes (and vice-versa).
+ *
+ * Individual screens also call useRequireRole for defense-in-depth, but this
+ * hook fires before any screen renders, providing a consistent first-layer guard.
+ */
+export function useProtectedRoute() {
+  const segments = useSegments();
+  const navState = useRootNavigationState();
+  const router = useRouter();
+  const token = useAuthStore((s) => s.token);
+  const user = useAuthStore((s) => s.user);
+
+  useEffect(() => {
+    // Wait until the navigation container is hydrated to avoid premature redirects.
+    if (!navState?.key) return;
+
+    const onLoginScreen = !segments[0];
+
+    if (!token) {
+      if (!onLoginScreen) router.replace("/");
+      return;
+    }
+
+    // Authenticated user on the login screen → send to their home route.
+    if (onLoginScreen) {
+      router.replace(user?.role === "PATIENT" ? "/my-cases" : "/upload");
+      return;
+    }
+
+    const prefix = segments[0] as string | undefined;
+    if (!prefix) return;
+
+    if (user?.role === "PATIENT" && PCP_ONLY.includes(prefix)) {
+      router.replace("/my-cases");
+      return;
+    }
+    if (user?.role === "PCP" && PATIENT_ONLY.includes(prefix)) {
+      router.replace("/upload");
+      return;
+    }
+  }, [token, segments, navState?.key, user?.role]);
+}

--- a/client/hooks/use-session-timeout.ts
+++ b/client/hooks/use-session-timeout.ts
@@ -1,0 +1,69 @@
+import { useEffect } from "react";
+import { AppState, Platform } from "react-native";
+import { useRouter } from "expo-router";
+import { useAuthStore } from "@/state/auth-store";
+
+/** Idle timeout before automatic logout. 30 minutes matches common clinical guidelines. */
+export const SESSION_TIMEOUT_MS = 30 * 60 * 1000;
+
+const WEB_EVENTS = ["mousemove", "click", "keydown", "scroll"] as const;
+
+/**
+ * Automatic session timeout hook. Call once from the root layout.
+ *
+ * Web: tracks mouse/keyboard/scroll events to update lastActivity.
+ * Native: treats each foreground transition as an activity signal and
+ *         checks the timeout whenever the app comes back to the foreground.
+ * Both: a 60-second interval checks whether the idle window has been exceeded.
+ */
+export function useSessionTimeout() {
+  const router = useRouter();
+  const token = useAuthStore((s) => s.token);
+  const updateActivity = useAuthStore((s) => s.updateActivity);
+  const clearAuth = useAuthStore((s) => s.clearAuth);
+
+  useEffect(() => {
+    // No-op when not authenticated.
+    if (!token) return;
+
+    function checkTimeout() {
+      const { lastActivity } = useAuthStore.getState();
+      if (lastActivity !== null && Date.now() - lastActivity > SESSION_TIMEOUT_MS) {
+        clearAuth();
+        router.replace("/");
+      }
+    }
+
+    // Check once per minute — low overhead, worst-case 60s overshoot.
+    const interval = setInterval(checkTimeout, 60_000);
+
+    if (Platform.OS === "web") {
+      function onActivity() {
+        updateActivity();
+      }
+      for (const e of WEB_EVENTS) {
+        document.addEventListener(e, onActivity, { passive: true });
+      }
+      return () => {
+        clearInterval(interval);
+        for (const e of WEB_EVENTS) {
+          document.removeEventListener(e, onActivity);
+        }
+      };
+    } else {
+      // On native: coming to foreground either triggers a timeout check or
+      // resets the activity clock if within the allowed window.
+      const sub = AppState.addEventListener("change", (nextState) => {
+        if (nextState === "active") {
+          checkTimeout();
+        } else {
+          updateActivity();
+        }
+      });
+      return () => {
+        clearInterval(interval);
+        sub.remove();
+      };
+    }
+  }, [token]);
+}

--- a/client/services/auth-service.ts
+++ b/client/services/auth-service.ts
@@ -43,7 +43,7 @@ export async function login(
     userId: String(payload.sub ?? email),
     email: String(payload.email ?? email),
     fullName: String(payload.full_name ?? email.split("@")[0]),
-    role: ((payload.role as UserRole) ?? "PCP"),
+    role: ((payload.role as UserRole) ?? "PATIENT"),
   };
 
   useAuthStore.getState().setAuth(tokenRes.access_token, user);

--- a/client/services/http.ts
+++ b/client/services/http.ts
@@ -19,6 +19,9 @@ export async function apiFetch<T>(
   });
   if (!res.ok) {
     const body = await res.json().catch(() => ({}));
+    if (res.status === 401) {
+      useAuthStore.getState().clearAuth();
+    }
     throw new Error(body?.detail ?? `Request failed (${res.status})`);
   }
   return res.json();

--- a/client/state/auth-store.ts
+++ b/client/state/auth-store.ts
@@ -1,16 +1,35 @@
 import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
 import type { UserInfo } from "@/types/api";
 
 interface AuthState {
   token: string | null;
   user: UserInfo | null;
+  lastActivity: number | null;
   setAuth: (token: string, user: UserInfo) => void;
   clearAuth: () => void;
+  updateActivity: () => void;
 }
 
-export const useAuthStore = create<AuthState>((set) => ({
-  token: null,
-  user: null,
-  setAuth: (token, user) => set({ token, user }),
-  clearAuth: () => set({ token: null, user: null }),
-}));
+const safeSessionStorage = {
+  getItem: (k: string) => { try { return sessionStorage.getItem(k); } catch { return null; } },
+  setItem: (k: string, v: string) => { try { sessionStorage.setItem(k, v); } catch {} },
+  removeItem: (k: string) => { try { sessionStorage.removeItem(k); } catch {} },
+};
+
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set) => ({
+      token: null,
+      user: null,
+      lastActivity: null,
+      setAuth: (token, user) => set({ token, user, lastActivity: Date.now() }),
+      clearAuth: () => set({ token: null, user: null, lastActivity: null }),
+      updateActivity: () => set({ lastActivity: Date.now() }),
+    }),
+    {
+      name: "dermatlas-auth",
+      storage: createJSONStorage(() => safeSessionStorage),
+    }
+  )
+);

--- a/client/state/current-case-store.ts
+++ b/client/state/current-case-store.ts
@@ -1,0 +1,53 @@
+import { create } from "zustand";
+
+interface CurrentCaseState {
+  // Written by upload.tsx before navigating to /compare
+  patientId: number | null;
+  patientMrn: string;
+  patientName: string;
+  queryId: string;
+  imageUri: string | null;
+  // Written by compare.tsx before navigating to /feedback
+  matchId: string;
+  referenceId: string;
+  diagnosis: string;
+  similarity: number | null;
+  referenceImageUri: string;
+
+  setCase: (p: {
+    patientId: number;
+    patientMrn: string;
+    patientName: string;
+    queryId: string;
+    imageUri: string | null;
+  }) => void;
+  setFeedbackTarget: (p: {
+    matchId: string;
+    referenceId: string;
+    diagnosis: string;
+    similarity: number | null;
+    referenceImageUri: string;
+  }) => void;
+  clear: () => void;
+}
+
+const EMPTY = {
+  patientId: null,
+  patientMrn: "",
+  patientName: "",
+  queryId: "",
+  imageUri: null,
+  matchId: "",
+  referenceId: "",
+  diagnosis: "",
+  similarity: null,
+  referenceImageUri: "",
+};
+
+// Intentionally NOT persisted — case context is transient and should die on refresh.
+export const useCurrentCaseStore = create<CurrentCaseState>((set) => ({
+  ...EMPTY,
+  setCase: (p) => set(p),
+  setFeedbackTarget: (p) => set(p),
+  clear: () => set(EMPTY),
+}));


### PR DESCRIPTION
…sion timeout

- Add global auth guard + role routing in _layout.tsx (useProtectedRoute)
- Add 30-min idle session timeout with web/native activity tracking (useSessionTimeout)
- Move PHI (patient name, MRN, diagnosis, image URIs) out of URL params into Zustand store (current-case-store); URLs now carry only opaque IDs
- Fix JWT role fallback from "PCP" to "PATIENT" (least-privileged default)
- Clear auth state and trigger redirect on 401 responses in apiFetch
- Persist auth state across web page refreshes via sessionStorage (tab-scoped)

Addresses audit findings C-1, C-2, C-3, C-4, H-1, H-2, H-3, H-4. Audit report: MVP_FRONTEND_AUDIT.md