### PR TITLE
Add patient case view with PCP visibility toggle

### DIFF
--- a/client/app.config.ts
+++ b/client/app.config.ts
@@ -21,6 +21,8 @@ export default ({ config }: ConfigContext): ExpoConfig => {
 
   return {
     ...config,
+    name: config.name ?? "DermAtlas",
+    slug: config.slug ?? "derm-atlas",
     extra: {
       apiBase,
       useMock,

--- a/client/app/case-detail.tsx
+++ b/client/app/case-detail.tsx
@@ -1,0 +1,320 @@
+import React, { useEffect, useState } from "react";
+import {
+  SafeAreaView,
+  View,
+  Text,
+  StyleSheet,
+  Pressable,
+  ScrollView,
+  ActivityIndicator,
+} from "react-native";
+import { useRouter, useLocalSearchParams } from "expo-router";
+import { MaterialCommunityIcons } from "@expo/vector-icons";
+import { Image } from "expo-image";
+import { useRequireRole } from "@/hooks/use-require-role";
+import { getMyCaseDetail } from "@/services/patient-service";
+import type { ClinicalImageDetail } from "@/types/api";
+import { DermAtlasColors as D } from "@/constants/theme";
+
+function formatDate(isoStr: string | null): string {
+  if (!isoStr) return "Unknown date";
+  try {
+    return new Intl.DateTimeFormat("en-US", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    }).format(new Date(isoStr));
+  } catch {
+    return isoStr;
+  }
+}
+
+export default function CaseDetail() {
+  const authorized = useRequireRole("PATIENT");
+  const router = useRouter();
+  const { queryId } = useLocalSearchParams<{ queryId: string }>();
+  const [data, setData] = useState<ClinicalImageDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [imgError, setImgError] = useState(false);
+
+  useEffect(() => {
+    if (!authorized || !queryId) return;
+    setError(null);
+    getMyCaseDetail(queryId)
+      .then(setData)
+      .catch((err: unknown) => {
+        setError(err instanceof Error ? err.message : "Failed to load case.");
+      })
+      .finally(() => setLoading(false));
+  }, [authorized, queryId]);
+
+  if (!authorized) return null;
+
+  const hasImage = !!data?.gcs_uri && !imgError;
+
+  return (
+    <SafeAreaView style={styles.safe}>
+      {/* Header */}
+      <View style={styles.header}>
+        <Pressable style={styles.backBtn} onPress={() => router.back()}>
+          <MaterialCommunityIcons name="arrow-left" size={20} color={D.onPrimary} />
+        </Pressable>
+        <View style={styles.headerCenter}>
+          <Text style={styles.headerTitle}>Case Details</Text>
+        </View>
+        <View style={styles.backBtn} />
+      </View>
+
+      <ScrollView contentContainerStyle={styles.scroll}>
+        {/* Loading */}
+        {loading && (
+          <View style={styles.centered}>
+            <ActivityIndicator size="large" color={D.primary} />
+            <Text style={styles.loadingText}>Loading case...</Text>
+          </View>
+        )}
+
+        {/* Error */}
+        {!loading && error && (
+          <View style={styles.page}>
+            <View style={styles.errorBanner}>
+              <MaterialCommunityIcons name="alert-circle-outline" size={18} color={D.danger} />
+              <Text style={styles.errorText}>{error}</Text>
+            </View>
+            <Pressable style={styles.retryBtn} onPress={() => router.back()}>
+              <Text style={styles.retryText}>Go Back</Text>
+            </Pressable>
+          </View>
+        )}
+
+        {/* Case detail */}
+        {!loading && !error && data && (
+          <View style={styles.page}>
+            {/* Image */}
+            <View style={styles.imageCard}>
+              {hasImage ? (
+                <Image
+                  source={{ uri: data.gcs_uri }}
+                  style={styles.caseImage}
+                  contentFit="cover"
+                  onError={() => setImgError(true)}
+                />
+              ) : (
+                <View style={styles.imagePlaceholder}>
+                  <MaterialCommunityIcons name="image-outline" size={56} color={D.border} />
+                  <Text style={styles.imagePlaceholderText}>No image available</Text>
+                </View>
+              )}
+            </View>
+
+            {/* Location & Date */}
+            <View style={styles.infoCard}>
+              <View style={styles.infoHeader}>
+                <MaterialCommunityIcons name="map-marker-outline" size={20} color={D.primary} />
+                <Text style={styles.infoTitle}>{data.lesion_location}</Text>
+              </View>
+              <View style={styles.divider} />
+              <View style={styles.infoRow}>
+                <MaterialCommunityIcons name="calendar-outline" size={16} color={D.muted} />
+                <Text style={styles.infoValue}>{formatDate(data.captured_at)}</Text>
+              </View>
+              {data.physician_name && (
+                <View style={styles.infoRow}>
+                  <MaterialCommunityIcons name="stethoscope" size={16} color={D.muted} />
+                  <Text style={styles.infoValue}>{data.physician_name}</Text>
+                </View>
+              )}
+              <View style={styles.infoRow}>
+                <MaterialCommunityIcons name="identifier" size={16} color={D.muted} />
+                <Text style={styles.infoValueMono}>{data.query_id.slice(-12)}</Text>
+              </View>
+            </View>
+
+            {/* Clinician Notes */}
+            <View style={styles.notesCard}>
+              <View style={styles.notesHeader}>
+                <MaterialCommunityIcons name="note-text-outline" size={18} color={D.primary} />
+                <Text style={styles.notesTitle}>Physician Notes</Text>
+              </View>
+              <View style={styles.divider} />
+              {data.clinician_notes ? (
+                <Text style={styles.notesBody}>{data.clinician_notes}</Text>
+              ) : (
+                <View style={styles.noNotesState}>
+                  <MaterialCommunityIcons name="text-box-remove-outline" size={24} color={D.border} />
+                  <Text style={styles.noNotesText}>
+                    No notes have been added for this case yet.
+                  </Text>
+                </View>
+              )}
+            </View>
+
+            {/* Disclaimer */}
+            <View style={styles.disclaimer}>
+              <MaterialCommunityIcons name="information-outline" size={14} color={D.muted} />
+              <Text style={styles.disclaimerText}>
+                This information is shared by your physician for your reference.
+                Contact your doctor with any questions or concerns.
+              </Text>
+            </View>
+          </View>
+        )}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: D.bg },
+
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    backgroundColor: D.primary,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    gap: 8,
+  },
+  backBtn: {
+    width: 38,
+    height: 38,
+    borderRadius: 10,
+    backgroundColor: D.onPrimaryOverlay,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  headerCenter: { flex: 1, alignItems: "center" },
+  headerTitle: { color: D.onPrimary, fontWeight: "700", fontSize: 17 },
+
+  scroll: { flexGrow: 1 },
+  page: {
+    padding: 20,
+    gap: 16,
+    maxWidth: 600,
+    alignSelf: "center",
+    width: "100%",
+  },
+
+  centered: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingVertical: 80,
+    gap: 12,
+  },
+  loadingText: { color: D.muted, fontSize: 14, fontWeight: "500" },
+
+  errorBanner: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    backgroundColor: D.dangerBg,
+    borderRadius: 10,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    borderWidth: 1,
+    borderColor: D.danger,
+  },
+  errorText: { color: D.danger, fontSize: 13, fontWeight: "600", flex: 1 },
+  retryBtn: {
+    alignSelf: "center",
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    borderRadius: 10,
+    backgroundColor: D.primary,
+  },
+  retryText: { color: D.onPrimary, fontWeight: "700", fontSize: 14 },
+
+  imageCard: {
+    borderRadius: 16,
+    overflow: "hidden",
+    borderWidth: 1.5,
+    borderColor: D.border,
+    backgroundColor: D.surface,
+  },
+  caseImage: {
+    width: "100%",
+    height: 260,
+  },
+  imagePlaceholder: {
+    height: 200,
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 8,
+    backgroundColor: D.bg,
+  },
+  imagePlaceholderText: { color: D.muted, fontSize: 13, fontWeight: "500" },
+
+  infoCard: {
+    backgroundColor: D.surface,
+    borderRadius: 16,
+    padding: 18,
+    borderWidth: 1.5,
+    borderColor: D.border,
+    gap: 12,
+  },
+  infoHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  infoTitle: { color: D.text, fontSize: 18, fontWeight: "700", flex: 1 },
+  divider: {
+    height: 1,
+    backgroundColor: D.border,
+    marginVertical: 2,
+  },
+  infoRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  infoValue: { color: D.text, fontSize: 14, fontWeight: "500" },
+  infoValueMono: { color: D.muted, fontSize: 12, fontWeight: "500", fontFamily: "monospace" },
+
+  notesCard: {
+    backgroundColor: D.surface,
+    borderRadius: 16,
+    padding: 18,
+    borderWidth: 1.5,
+    borderColor: D.border,
+    gap: 12,
+  },
+  notesHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  notesTitle: { color: D.text, fontSize: 15, fontWeight: "700" },
+  notesBody: {
+    color: D.text,
+    fontSize: 14,
+    fontWeight: "400",
+    lineHeight: 22,
+  },
+  noNotesState: {
+    alignItems: "center",
+    paddingVertical: 20,
+    gap: 8,
+  },
+  noNotesText: { color: D.muted, fontSize: 13, textAlign: "center" },
+
+  disclaimer: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: 6,
+    paddingHorizontal: 4,
+    paddingVertical: 8,
+  },
+  disclaimerText: {
+    color: D.muted,
+    fontSize: 11,
+    fontWeight: "500",
+    lineHeight: 16,
+    flex: 1,
+  },
+});

--- a/client/app/compare.tsx
+++ b/client/app/compare.tsx
@@ -16,6 +16,7 @@ import { useCurrentCaseStore } from "@/state/current-case-store";
 import { useRequireRole } from "@/hooks/use-require-role";
 import { analyzeLesion } from "@/services/lesion-service";
 import { DEMO_IMAGES, DEMO_UPLOAD_IMAGE } from "@/constants/demo-images";
+import { VisibilityToggle } from "@/components/visibility-toggle";
 import type { AnalyzeMatch } from "@/types/api";
 import { displayRole } from "@/types/api";
 import { DermAtlasColors as D } from "@/constants/theme";
@@ -104,6 +105,11 @@ export default function Compare() {
               ) : null}
             </View>
           </View>
+
+          {/* Patient visibility toggle */}
+          {queryId && (
+            <VisibilityToggle queryId={queryId} />
+          )}
 
           {/* Submitted image */}
           <View style={styles.imageSection}>

--- a/client/app/my-cases.tsx
+++ b/client/app/my-cases.tsx
@@ -71,6 +71,10 @@ export default function MyCases() {
     router.replace("/");
   }
 
+  function handleCasePress(queryId: string) {
+    router.push(`/case-detail?queryId=${encodeURIComponent(queryId)}`);
+  }
+
   return (
     <SafeAreaView style={styles.safe}>
       {/* Header */}
@@ -119,6 +123,12 @@ export default function MyCases() {
                 </View>
               </View>
               <Text style={styles.profileEmail}>{user?.email ?? "—"}</Text>
+              {data?.physician_name && (
+                <View style={styles.physicianRow}>
+                  <MaterialCommunityIcons name="stethoscope" size={12} color={D.muted} />
+                  <Text style={styles.physicianText}>{data.physician_name}</Text>
+                </View>
+              )}
             </View>
           </View>
 
@@ -151,50 +161,65 @@ export default function MyCases() {
                 size={48}
                 color={D.border}
               />
-              <Text style={styles.emptyTitle}>No cases submitted yet</Text>
+              <Text style={styles.emptyTitle}>No cases available yet</Text>
               <Text style={styles.emptySubtitle}>
-                Your clinician will submit images on your behalf
+                Your physician will share case results when they are ready for you to view.
               </Text>
             </View>
           )}
 
-          {/* Case list */}
-          {!loading && !error && data && data.clinical_images.map((img) => (
-            <CaseCard key={img.query_id} image={img} />
-          ))}
+          {/* Case tiles */}
+          {!loading && !error && data && (
+            <View style={styles.tileGrid}>
+              {data.clinical_images.map((img) => (
+                <CaseCard
+                  key={img.query_id}
+                  image={img}
+                  onPress={() => handleCasePress(img.query_id)}
+                />
+              ))}
+            </View>
+          )}
         </View>
       </ScrollView>
     </SafeAreaView>
   );
 }
 
-function CaseCard({ image }: { image: ClinicalImageSummary }) {
+function CaseCard({ image, onPress }: { image: ClinicalImageSummary; onPress: () => void }) {
   const [imgError, setImgError] = useState(false);
   const hasImage = !!image.gcs_uri && !imgError;
 
   return (
     <Pressable
-      style={({ pressed }) => [styles.caseCard, pressed && styles.caseCardPressed]}
+      style={({ pressed }) => [styles.tile, pressed && styles.tilePressed]}
+      onPress={onPress}
     >
-      <View style={styles.thumbnail}>
+      <View style={styles.tileThumbnail}>
         {hasImage ? (
           <Image
             source={{ uri: image.gcs_uri }}
-            style={styles.thumbnailImage}
+            style={styles.tileThumbnailImage}
             contentFit="cover"
             onError={() => setImgError(true)}
           />
         ) : (
-          <MaterialCommunityIcons name="image-outline" size={28} color={D.border} />
+          <View style={styles.tilePlaceholder}>
+            <MaterialCommunityIcons name="image-outline" size={32} color={D.border} />
+          </View>
         )}
       </View>
-      <View style={styles.caseInfo}>
-        <Text style={styles.caseLocation}>{image.lesion_location}</Text>
-        <Text style={styles.caseMeta}>
-          {formatDate(image.captured_at)} · {image.query_id.slice(-8)}
-        </Text>
+      <View style={styles.tileBody}>
+        <View style={styles.tileLocationRow}>
+          <MaterialCommunityIcons name="map-marker-outline" size={14} color={D.primary} />
+          <Text style={styles.tileLocation} numberOfLines={1}>{image.lesion_location}</Text>
+        </View>
+        <Text style={styles.tileMeta}>{formatDate(image.captured_at)}</Text>
       </View>
-      <MaterialCommunityIcons name="chevron-right" size={20} color={D.muted} />
+      <View style={styles.tileFooter}>
+        <Text style={styles.tileAction}>View Details</Text>
+        <MaterialCommunityIcons name="chevron-right" size={16} color={D.primary} />
+      </View>
     </Pressable>
   );
 }
@@ -235,7 +260,7 @@ const styles = StyleSheet.create({
   page: {
     padding: 20,
     gap: 16,
-    maxWidth: 600,
+    maxWidth: 720,
     alignSelf: "center",
     width: "100%",
   },
@@ -275,6 +300,13 @@ const styles = StyleSheet.create({
   },
   badgeText: { color: D.primary, fontSize: 11, fontWeight: "600" },
   profileEmail: { color: D.muted, fontSize: 12, fontWeight: "500" },
+  physicianRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+    marginTop: 2,
+  },
+  physicianText: { color: D.muted, fontSize: 12, fontWeight: "500" },
 
   sectionLabel: {
     fontSize: 13,
@@ -303,32 +335,56 @@ const styles = StyleSheet.create({
     gap: 10,
   },
   emptyTitle: { color: D.text, fontSize: 16, fontWeight: "600" },
-  emptySubtitle: { color: D.muted, fontSize: 13, textAlign: "center" },
+  emptySubtitle: { color: D.muted, fontSize: 13, textAlign: "center", maxWidth: 280 },
 
-  caseCard: {
+  tileGrid: {
     flexDirection: "row",
-    alignItems: "center",
+    flexWrap: "wrap",
     gap: 14,
+  },
+
+  tile: {
+    width: "100%",
+    maxWidth: 340,
+    flexGrow: 1,
+    flexBasis: "45%",
     backgroundColor: D.surface,
-    borderRadius: 14,
-    padding: 14,
+    borderRadius: 16,
     borderWidth: 1.5,
     borderColor: D.border,
-  },
-  caseCardPressed: { opacity: 0.8 },
-  thumbnail: {
-    width: 60,
-    height: 60,
-    borderRadius: 10,
-    backgroundColor: D.bg,
-    borderWidth: 1,
-    borderColor: D.border,
-    alignItems: "center",
-    justifyContent: "center",
     overflow: "hidden",
   },
-  thumbnailImage: { width: "100%", height: "100%" },
-  caseInfo: { flex: 1, gap: 4 },
-  caseLocation: { color: D.text, fontSize: 14, fontWeight: "600" },
-  caseMeta: { color: D.muted, fontSize: 12, fontWeight: "500" },
+  tilePressed: { opacity: 0.85, transform: [{ scale: 0.98 }] },
+  tileThumbnail: {
+    height: 140,
+    backgroundColor: D.bg,
+    borderBottomWidth: 1,
+    borderBottomColor: D.border,
+  },
+  tileThumbnailImage: { width: "100%", height: "100%" },
+  tilePlaceholder: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  tileBody: {
+    padding: 14,
+    gap: 4,
+  },
+  tileLocationRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+  },
+  tileLocation: { color: D.text, fontSize: 15, fontWeight: "700", flex: 1 },
+  tileMeta: { color: D.muted, fontSize: 12, fontWeight: "500" },
+  tileFooter: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "flex-end",
+    paddingHorizontal: 14,
+    paddingBottom: 12,
+    gap: 2,
+  },
+  tileAction: { color: D.primary, fontSize: 12, fontWeight: "700" },
 });

--- a/client/app/my-cases.tsx
+++ b/client/app/my-cases.tsx
@@ -72,7 +72,7 @@ export default function MyCases() {
   }
 
   function handleCasePress(queryId: string) {
-    router.push(`/case-detail?queryId=${encodeURIComponent(queryId)}`);
+    router.push({ pathname: "/case-detail", params: { queryId } });
   }
 
   return (

--- a/client/components/visibility-toggle.tsx
+++ b/client/components/visibility-toggle.tsx
@@ -1,0 +1,99 @@
+import React, { useState } from "react";
+import { View, Text, Pressable, StyleSheet, ActivityIndicator } from "react-native";
+import { MaterialCommunityIcons } from "@expo/vector-icons";
+import { toggleCaseVisibility } from "@/services/patient-service";
+import { DermAtlasColors as D } from "@/constants/theme";
+
+type Props = {
+  queryId: string;
+  initialVisible?: boolean;
+};
+
+export function VisibilityToggle({ queryId, initialVisible = false }: Props) {
+  const [visible, setVisible] = useState(initialVisible);
+  const [toggling, setToggling] = useState(false);
+
+  async function handleToggle() {
+    setToggling(true);
+    try {
+      const res = await toggleCaseVisibility(queryId, !visible);
+      setVisible(res.visible_to_patient);
+    } catch {
+      // Revert on failure — state stays as-is
+    } finally {
+      setToggling(false);
+    }
+  }
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.info}>
+        <MaterialCommunityIcons
+          name={visible ? "eye-outline" : "eye-off-outline"}
+          size={18}
+          color={visible ? D.success : D.muted}
+        />
+        <View style={styles.textWrap}>
+          <Text style={styles.label}>Patient Visibility</Text>
+          <Text style={styles.hint}>
+            {visible
+              ? "Patient can see this case and your notes"
+              : "This case is hidden from the patient"}
+          </Text>
+        </View>
+      </View>
+      <Pressable
+        style={[
+          styles.toggle,
+          visible ? styles.toggleOn : styles.toggleOff,
+        ]}
+        onPress={handleToggle}
+        disabled={toggling}
+      >
+        {toggling ? (
+          <ActivityIndicator size="small" color={visible ? D.onPrimary : D.muted} />
+        ) : (
+          <Text style={[styles.toggleText, visible ? styles.toggleTextOn : styles.toggleTextOff]}>
+            {visible ? "Visible" : "Hidden"}
+          </Text>
+        )}
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    backgroundColor: D.surface,
+    borderRadius: 12,
+    padding: 14,
+    borderWidth: 1.5,
+    borderColor: D.border,
+    gap: 12,
+  },
+  info: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: 10,
+  },
+  textWrap: { flex: 1, gap: 2 },
+  label: { color: D.text, fontSize: 13, fontWeight: "700" },
+  hint: { color: D.muted, fontSize: 11, fontWeight: "500", lineHeight: 16 },
+
+  toggle: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 8,
+    minWidth: 80,
+    alignItems: "center",
+  },
+  toggleOn: { backgroundColor: D.success },
+  toggleOff: { backgroundColor: D.bg, borderWidth: 1, borderColor: D.border },
+  toggleText: { fontSize: 12, fontWeight: "700" },
+  toggleTextOn: { color: D.onPrimary },
+  toggleTextOff: { color: D.muted },
+});

--- a/client/hooks/use-protected-route.ts
+++ b/client/hooks/use-protected-route.ts
@@ -20,16 +20,16 @@ export function useProtectedRoute() {
   const [navReady, setNavReady] = useState(false);
 
   useEffect(() => {
-    if (navRef?.isReady) {
+    if (navRef?.isReady?.()) {
       setNavReady(true);
       return;
     }
     // Listen for when navigation becomes ready
     const unsubscribe = navRef?.addListener?.("state", () => {
-      if (navRef.isReady) setNavReady(true);
+      if (navRef.isReady?.()) setNavReady(true);
     });
     return () => { unsubscribe?.(); };
-  }, [navRef, navRef?.isReady]);
+  }, [navRef]);
 
   useEffect(() => {
     if (!hydrated || !navReady) return;

--- a/client/services/patient-service.ts
+++ b/client/services/patient-service.ts
@@ -1,9 +1,11 @@
-import type { PatientMeResponse, PatientResponse } from "@/types/api";
+import type {
+  ClinicalImageDetail,
+  PatientMeResponse,
+  PatientResponse,
+  VisibilityToggleResponse,
+} from "@/types/api";
 import { apiFetch, USE_MOCK, delay } from "./http";
 
-// Demo patients — mirrors the mockPatients array in app.json extra config.
-// Defined here as a direct import to avoid Expo's Constants.expoConfig.extra
-// dropping complex types (arrays) at runtime in certain web build modes.
 const MOCK_PATIENTS: PatientResponse[] = [
   { patient_id: 1, mrn_internal: "MRN-001", full_name: "Alice Johnson", date_of_birth: "1985-06-15", gender: "Female", clinical_images: [] },
   { patient_id: 2, mrn_internal: "MRN-002", full_name: "Robert Chen", date_of_birth: "1972-11-03", gender: "Male", clinical_images: [] },
@@ -11,6 +13,66 @@ const MOCK_PATIENTS: PatientResponse[] = [
   { patient_id: 4, mrn_internal: "MRN-004", full_name: "James Williams", date_of_birth: "1965-09-08", gender: "Male", clinical_images: [] },
   { patient_id: 5, mrn_internal: "MRN-005", full_name: "Taylor Kim", date_of_birth: "2001-01-30", gender: "Non-binary", clinical_images: [] },
 ];
+
+const MOCK_PATIENT_CASES: PatientMeResponse = {
+  user_id: 99,
+  full_name: "Demo Patient",
+  email: "patient@demo.com",
+  physician_name: "Dr. Sarah Chen",
+  clinical_images: [
+    {
+      query_id: "mock-q-1-abcd1234",
+      gcs_uri: "",
+      captured_at: "2026-03-15T10:30:00Z",
+      lesion_location: "Left forearm",
+      visible_to_patient: true,
+    },
+    {
+      query_id: "mock-q-2-efgh5678",
+      gcs_uri: "",
+      captured_at: "2026-02-01T14:00:00Z",
+      lesion_location: "Upper back",
+      visible_to_patient: true,
+    },
+    {
+      query_id: "mock-q-3-ijkl9012",
+      gcs_uri: "",
+      captured_at: "2026-01-10T09:15:00Z",
+      lesion_location: "Right shoulder",
+      visible_to_patient: true,
+    },
+  ],
+};
+
+const MOCK_CASE_DETAILS: Record<string, ClinicalImageDetail> = {
+  "mock-q-1-abcd1234": {
+    query_id: "mock-q-1-abcd1234",
+    gcs_uri: "",
+    captured_at: "2026-03-15T10:30:00Z",
+    lesion_location: "Left forearm",
+    clinician_notes: "Irregular borders observed. Recommend follow-up in 3 months. No immediate concern but monitoring advised.",
+    visible_to_patient: true,
+    physician_name: "Dr. Sarah Chen",
+  },
+  "mock-q-2-efgh5678": {
+    query_id: "mock-q-2-efgh5678",
+    gcs_uri: "",
+    captured_at: "2026-02-01T14:00:00Z",
+    lesion_location: "Upper back",
+    clinician_notes: "Symmetric, uniform color. Consistent with benign nevus. No action required at this time.",
+    visible_to_patient: true,
+    physician_name: "Dr. Sarah Chen",
+  },
+  "mock-q-3-ijkl9012": {
+    query_id: "mock-q-3-ijkl9012",
+    gcs_uri: "",
+    captured_at: "2026-01-10T09:15:00Z",
+    lesion_location: "Right shoulder",
+    clinician_notes: null,
+    visible_to_patient: true,
+    physician_name: "Dr. Sarah Chen",
+  },
+};
 
 export async function getPatient(patientId: number): Promise<PatientResponse> {
   if (USE_MOCK) {
@@ -43,32 +105,38 @@ export async function getPatients(): Promise<PatientResponse[]> {
 export async function getMyPatientCases(): Promise<PatientMeResponse> {
   if (USE_MOCK) {
     await delay(400);
-    return {
-      user_id: 99,
-      full_name: "Demo Patient",
-      email: "patient@demo.com",
-      clinical_images: [
-        {
-          query_id: "mock-q-1-abcd1234",
-          gcs_uri: "",
-          captured_at: "2026-03-15T10:30:00Z",
-          lesion_location: "Left forearm",
-        },
-        {
-          query_id: "mock-q-2-efgh5678",
-          gcs_uri: "",
-          captured_at: "2026-02-01T14:00:00Z",
-          lesion_location: "Upper back",
-        },
-        {
-          query_id: "mock-q-3-ijkl9012",
-          gcs_uri: "",
-          captured_at: "2026-01-10T09:15:00Z",
-          lesion_location: "Right shoulder",
-        },
-      ],
-    };
+    return MOCK_PATIENT_CASES;
   }
 
   return apiFetch<PatientMeResponse>("/patients/me");
+}
+
+export async function getMyCaseDetail(queryId: string): Promise<ClinicalImageDetail> {
+  if (USE_MOCK) {
+    await delay(300);
+    const detail = MOCK_CASE_DETAILS[queryId];
+    if (!detail) throw new Error("Case not found");
+    return detail;
+  }
+
+  return apiFetch<ClinicalImageDetail>(`/patients/me/cases/${queryId}`);
+}
+
+export async function toggleCaseVisibility(
+  queryId: string,
+  visible: boolean,
+): Promise<VisibilityToggleResponse> {
+  if (USE_MOCK) {
+    await delay(300);
+    return { query_id: queryId, visible_to_patient: visible };
+  }
+
+  return apiFetch<VisibilityToggleResponse>(
+    `/clinical-images/${queryId}/visibility`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ visible_to_patient: visible }),
+    },
+  );
 }

--- a/client/types/api.ts
+++ b/client/types/api.ts
@@ -48,6 +48,18 @@ export interface ClinicalImageSummary {
   gcs_uri: string;
   captured_at: string | null;
   lesion_location: string;
+  visible_to_patient: boolean;
+}
+
+// GET /patients/me/cases/{query_id}
+export interface ClinicalImageDetail {
+  query_id: string;
+  gcs_uri: string;
+  captured_at: string | null;
+  lesion_location: string;
+  clinician_notes: string | null;
+  visible_to_patient: boolean;
+  physician_name: string | null;
 }
 
 export interface PatientResponse {
@@ -64,5 +76,12 @@ export interface PatientMeResponse {
   user_id: number;
   full_name: string;
   email: string;
+  physician_name: string | null;
   clinical_images: ClinicalImageSummary[];
+}
+
+// PATCH /clinical-images/{query_id}/visibility
+export interface VisibilityToggleResponse {
+  query_id: string;
+  visible_to_patient: boolean;
 }

--- a/server/alembic/versions/c4d8e3f2a719_add_patient_user_id_and_visibility.py
+++ b/server/alembic/versions/c4d8e3f2a719_add_patient_user_id_and_visibility.py
@@ -1,0 +1,37 @@
+"""add patient user_id and visible_to_patient
+
+Revision ID: c4d8e3f2a719
+Revises: b3c9f2a1e507
+Create Date: 2026-04-14 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c4d8e3f2a719'
+down_revision: Union[str, Sequence[str], None] = 'b3c9f2a1e507'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'patients',
+        sa.Column('user_id', sa.Integer(), sa.ForeignKey('users.user_id'), nullable=True, unique=True)
+    )
+    op.create_index('ix_patients_user_id', 'patients', ['user_id'])
+
+    op.add_column(
+        'clinical_images',
+        sa.Column('visible_to_patient', sa.Boolean(), nullable=False, server_default='0')
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('clinical_images', 'visible_to_patient')
+    op.drop_index('ix_patients_user_id', table_name='patients')
+    op.drop_column('patients', 'user_id')

--- a/server/app/api/api_v1/endpoints/lesion.py
+++ b/server/app/api/api_v1/endpoints/lesion.py
@@ -92,7 +92,7 @@ async def analyze_lesion(
     # --- Generate embedding from the uploaded image ---
     try:
         embedding = _get_image_embedding(image.gcs_image_uri)
-    except Exception as exc:
+    except Exception:
         logger.exception("Failed to generate image embedding for %s", image.gcs_image_uri)
         raise HTTPException(status_code=503, detail="Image embedding service unavailable")
 
@@ -108,7 +108,7 @@ async def analyze_lesion(
             num_neighbors=_MAX_RESULTS,
         )
         neighbors = response[0] if response else []
-    except Exception as exc:
+    except Exception:
         logger.exception("Vertex AI vector search failed")
         raise HTTPException(status_code=503, detail="Vector search service unavailable")
 

--- a/server/app/api/api_v1/endpoints/patients.py
+++ b/server/app/api/api_v1/endpoints/patients.py
@@ -1,4 +1,4 @@
-"""Patient endpoints — list and detail views for PCP-owned patients."""
+"""Patient endpoints — list, detail, case views, and visibility toggle."""
 
 from __future__ import annotations
 
@@ -14,9 +14,28 @@ from app.models.audit_log import AuditLog
 from app.models.clinical_image import ClinicalImage
 from app.models.patient import Patient
 from app.models.user import User, UserRole
-from app.schemas.patient import ClinicalImageSummary, PatientMeResponse, PatientResponse
+from app.schemas.patient import (
+    ClinicalImageDetail,
+    ClinicalImageSummary,
+    PatientMeResponse,
+    PatientResponse,
+    VisibilityUpdate,
+)
 
 router = APIRouter()
+
+
+def _image_summary(img: ClinicalImage) -> ClinicalImageSummary:
+    return ClinicalImageSummary(
+        query_id=img.query_id,
+        gcs_uri=img.gcs_image_uri,
+        captured_at=img.captured_at.isoformat() if img.captured_at else None,
+        lesion_location=img.lesion_location,
+        visible_to_patient=img.visible_to_patient,
+    )
+
+
+# ── Patient self-service ─────────────────────────────────────────────
 
 
 @router.get("/patients/me", response_model=PatientMeResponse)
@@ -27,9 +46,27 @@ async def get_my_cases(
     if current_user.role != UserRole.PATIENT:
         raise HTTPException(status_code=403, detail="Patient access only")
 
+    patient_result = await db.execute(
+        select(Patient).where(Patient.user_id == current_user.user_id)
+    )
+    patient = patient_result.scalar_one_or_none()
+    if patient is None:
+        raise HTTPException(status_code=404, detail="No patient record linked to this account")
+
+    physician_name: str | None = None
+    physician_result = await db.execute(
+        select(User).where(User.user_id == patient.primary_physician_id)
+    )
+    physician = physician_result.scalar_one_or_none()
+    if physician:
+        physician_name = physician.full_name
+
     images_result = await db.execute(
         select(ClinicalImage)
-        .where(ClinicalImage.user_id == current_user.user_id)
+        .where(
+            ClinicalImage.patient_id == patient.patient_id,
+            ClinicalImage.visible_to_patient.is_(True),
+        )
         .order_by(ClinicalImage.captured_at.desc())
     )
     images = images_result.scalars().all()
@@ -38,16 +75,95 @@ async def get_my_cases(
         user_id=current_user.user_id,
         full_name=current_user.full_name,
         email=current_user.email,
-        clinical_images=[
-            ClinicalImageSummary(
-                query_id=img.query_id,
-                gcs_uri=img.gcs_image_uri,
-                captured_at=img.captured_at.isoformat() if img.captured_at else None,
-                lesion_location=img.lesion_location,
-            )
-            for img in images
-        ],
+        physician_name=physician_name,
+        clinical_images=[_image_summary(img) for img in images],
     )
+
+
+@router.get("/patients/me/cases/{query_id}", response_model=ClinicalImageDetail)
+async def get_my_case_detail(
+    query_id: str = Path(...),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ClinicalImageDetail:
+    if current_user.role != UserRole.PATIENT:
+        raise HTTPException(status_code=403, detail="Patient access only")
+
+    patient_result = await db.execute(
+        select(Patient).where(Patient.user_id == current_user.user_id)
+    )
+    patient = patient_result.scalar_one_or_none()
+    if patient is None:
+        raise HTTPException(status_code=404, detail="No patient record linked to this account")
+
+    img_result = await db.execute(
+        select(ClinicalImage).where(
+            ClinicalImage.query_id == query_id,
+            ClinicalImage.patient_id == patient.patient_id,
+        )
+    )
+    img = img_result.scalar_one_or_none()
+    if img is None or not img.visible_to_patient:
+        raise HTTPException(status_code=404, detail="Case not found")
+
+    physician_result = await db.execute(
+        select(User).where(User.user_id == img.user_id)
+    )
+    physician = physician_result.scalar_one_or_none()
+
+    db.add(
+        AuditLog(
+            user_id=current_user.user_id,
+            action="VIEW_OWN_CASE",
+            target_resource=f"image:{query_id}",
+        )
+    )
+    await db.flush()
+
+    return ClinicalImageDetail(
+        query_id=img.query_id,
+        gcs_uri=img.gcs_image_uri,
+        captured_at=img.captured_at.isoformat() if img.captured_at else None,
+        lesion_location=img.lesion_location,
+        clinician_notes=img.clinician_notes,
+        visible_to_patient=img.visible_to_patient,
+        physician_name=physician.full_name if physician else None,
+    )
+
+
+# ── PCP visibility toggle ────────────────────────────────────────────
+
+
+@router.patch("/clinical-images/{query_id}/visibility")
+async def toggle_visibility(
+    body: VisibilityUpdate,
+    query_id: str = Path(...),
+    current_user: User = Depends(require_pcp),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    img_result = await db.execute(
+        select(ClinicalImage).where(ClinicalImage.query_id == query_id)
+    )
+    img = img_result.scalar_one_or_none()
+    if img is None:
+        raise HTTPException(status_code=404, detail="Clinical image not found")
+    if img.user_id != current_user.user_id:
+        raise HTTPException(status_code=403, detail="Not your clinical image")
+
+    img.visible_to_patient = body.visible_to_patient
+    db.add(
+        AuditLog(
+            user_id=current_user.user_id,
+            action="TOGGLE_VISIBILITY",
+            target_resource=f"image:{query_id}",
+        )
+    )
+    await db.flush()
+
+    return {"query_id": query_id, "visible_to_patient": img.visible_to_patient}
+
+
+# ── PCP patient management ───────────────────────────────────────────
 
 
 @router.get("/patients", response_model=List[PatientResponse])
@@ -73,15 +189,7 @@ async def list_patients(
                 full_name=patient.full_name,
                 date_of_birth=patient.date_of_birth,
                 gender=patient.gender,
-                clinical_images=[
-                    ClinicalImageSummary(
-                        query_id=img.query_id,
-                        gcs_uri=img.gcs_image_uri,
-                        captured_at=img.captured_at.isoformat() if img.captured_at else None,
-                        lesion_location=img.lesion_location,
-                    )
-                    for img in images
-                ],
+                clinical_images=[_image_summary(img) for img in images],
             )
         )
     return responses
@@ -93,7 +201,6 @@ async def get_patient(
     current_user: User = Depends(require_pcp),
     db: AsyncSession = Depends(get_db),
 ) -> PatientResponse:
-    # --- Fetch patient ---
     result = await db.execute(select(Patient).where(Patient.patient_id == patient_id))
     patient = result.scalar_one_or_none()
     if patient is None:
@@ -101,13 +208,11 @@ async def get_patient(
     if patient.primary_physician_id != current_user.user_id:
         raise HTTPException(status_code=403, detail="Access to this patient is forbidden")
 
-    # --- Fetch clinical images ---
     images_result = await db.execute(
         select(ClinicalImage).where(ClinicalImage.patient_id == patient_id)
     )
     images = images_result.scalars().all()
 
-    # --- Audit log (HIPAA) ---
     db.add(
         AuditLog(
             user_id=current_user.user_id,
@@ -123,13 +228,5 @@ async def get_patient(
         full_name=patient.full_name,
         date_of_birth=patient.date_of_birth,
         gender=patient.gender,
-        clinical_images=[
-            ClinicalImageSummary(
-                query_id=img.query_id,
-                gcs_uri=img.gcs_image_uri,
-                captured_at=img.captured_at.isoformat() if img.captured_at else None,
-                lesion_location=img.lesion_location,
-            )
-            for img in images
-        ],
+        clinical_images=[_image_summary(img) for img in images],
     )

--- a/server/app/api/api_v1/endpoints/users.py
+++ b/server/app/api/api_v1/endpoints/users.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 

--- a/server/app/models/clinical_image.py
+++ b/server/app/models/clinical_image.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import DateTime, ForeignKey, Integer, String
+from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db.base import Base
@@ -27,6 +27,9 @@ class ClinicalImage(Base):
     vertex_vector_id: Mapped[str | None] = mapped_column(String(100), nullable=True, default="")
     lesion_location: Mapped[str] = mapped_column(String(255), nullable=False)
     clinician_notes: Mapped[str | None] = mapped_column(String(2000), nullable=True)
+    visible_to_patient: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="0"
+    )
     captured_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),

--- a/server/app/models/patient.py
+++ b/server/app/models/patient.py
@@ -14,6 +14,9 @@ class Patient(Base):
     __tablename__ = "patients"
 
     patient_id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    user_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("users.user_id"), nullable=True, unique=True, index=True
+    )
     primary_physician_id: Mapped[int] = mapped_column(
         Integer, ForeignKey("users.user_id"), nullable=False, index=True
     )

--- a/server/app/models/user.py
+++ b/server/app/models/user.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import enum
 from datetime import datetime, timezone
 
-from sqlalchemy import Boolean, DateTime, Enum as SAEnum, Integer, String
+from sqlalchemy import DateTime, Enum as SAEnum, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db.base import Base

--- a/server/app/schemas/patient.py
+++ b/server/app/schemas/patient.py
@@ -10,6 +10,17 @@ class ClinicalImageSummary(BaseModel):
     gcs_uri: str
     captured_at: Optional[str] = None
     lesion_location: str
+    visible_to_patient: bool = False
+
+
+class ClinicalImageDetail(BaseModel):
+    query_id: str
+    gcs_uri: str
+    captured_at: Optional[str] = None
+    lesion_location: str
+    clinician_notes: Optional[str] = None
+    visible_to_patient: bool = False
+    physician_name: Optional[str] = None
 
 
 class PatientResponse(BaseModel):
@@ -25,4 +36,9 @@ class PatientMeResponse(BaseModel):
     user_id: int
     full_name: str
     email: str
+    physician_name: Optional[str] = None
     clinical_images: List[ClinicalImageSummary]
+
+
+class VisibilityUpdate(BaseModel):
+    visible_to_patient: bool

--- a/server/scripts/populate_reference_atlas.py
+++ b/server/scripts/populate_reference_atlas.py
@@ -18,9 +18,6 @@ Usage:
 
 import asyncio
 import csv
-import os
-import sys
-from pathlib import Path
 
 import numpy as np
 

--- a/server/scripts/seed_test_data.py
+++ b/server/scripts/seed_test_data.py
@@ -264,13 +264,13 @@ def get_connection():
         use_cloud_sql = os.environ.get("USE_CLOUD_SQL_CONNECTOR", "").lower() == "true"
 
     if use_cloud_sql:
-        print(f"Connecting via Cloud SQL Connector...")
+        print("Connecting via Cloud SQL Connector...")
         print(f"  Instance: {os.environ.get('CLOUD_SQL_INSTANCE_CONNECTION_NAME', '?')}")
         print(f"  Database: {os.environ.get('PGDATABASE', '?')}")
         return connect_cloud_sql()
 
     if database_url:
-        print(f"Connecting via direct URL...")
+        print("Connecting via direct URL...")
         return connect_direct(database_url)
 
     print("ERROR: No database connection configured.", file=sys.stderr)

--- a/server/scripts/seed_users.py
+++ b/server/scripts/seed_users.py
@@ -17,8 +17,8 @@ import sys
 # Allow running from the server/ directory
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from sqlalchemy import select, text
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.core.auth import get_password_hash
 from app.core.config import get_settings

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -10,7 +10,6 @@ Engine strategy:
 
 from __future__ import annotations
 
-import uuid
 from contextlib import asynccontextmanager
 from typing import AsyncGenerator
 

--- a/server/tests/integration/test_analyze.py
+++ b/server/tests/integration/test_analyze.py
@@ -5,7 +5,6 @@ TDD — these will be red until the analyze endpoint, Vertex AI service,
 and audit log model are implemented.
 """
 
-import pytest
 
 ANALYZE_URL = "/api/v1/lesion/analyze"
 

--- a/server/tests/integration/test_auth.py
+++ b/server/tests/integration/test_auth.py
@@ -6,11 +6,8 @@ Tests are written contract-first (TDD): they will fail (red) until the
 auth endpoint + User model + auth utilities are implemented.
 """
 
-import pytest
 
 from tests.fixtures.test_data import (
-    OTHER_PCP_EMAIL,
-    OTHER_PCP_PASSWORD,
     PATIENT_EMAIL,
     PATIENT_PASSWORD,
     PCP_EMAIL,

--- a/server/tests/integration/test_feedback.py
+++ b/server/tests/integration/test_feedback.py
@@ -4,7 +4,6 @@ Integration tests for POST /api/v1/feedback.
 TDD — red until feedback endpoint + RecommendationFeedback model exist.
 """
 
-import pytest
 
 from tests.fixtures.test_data import feedback_payload
 

--- a/server/tests/integration/test_patients.py
+++ b/server/tests/integration/test_patients.py
@@ -4,7 +4,6 @@ Integration tests for GET /api/v1/patients/{patient_id}.
 TDD — red until patients endpoint + Patient model + audit log are implemented.
 """
 
-import pytest
 
 PATIENTS_URL = "/api/v1/patients"
 

--- a/server/tests/integration/test_upload.py
+++ b/server/tests/integration/test_upload.py
@@ -7,11 +7,9 @@ and GCS integration are implemented.
 
 import io
 
-import pytest
 
 from tests.fixtures.test_data import (
     CLINICIAN_NOTES,
-    GCS_URI,
     LESION_LOCATION,
     make_jpeg_bytes,
     make_png_bytes,

--- a/server/tests/unit/test_auth_utils.py
+++ b/server/tests/unit/test_auth_utils.py
@@ -1,6 +1,5 @@
 """Unit tests for JWT creation/verification and password hashing utilities."""
 
-import time
 
 import pytest
 

--- a/server/tests/unit/test_config.py
+++ b/server/tests/unit/test_config.py
@@ -1,7 +1,6 @@
 """Unit tests for application settings / config loading."""
 
 import os
-from functools import lru_cache
 
 import pytest
 


### PR DESCRIPTION
- Fix /patients/me to query by patient record instead of doctor's user_id
- Add visible_to_patient boolean to ClinicalImage (default false)
- Add user_id FK on Patient to link patient records to user accounts
- New GET /patients/me/cases/{query_id} endpoint for case detail
- New PATCH /clinical-images/{query_id}/visibility for PCP toggle
- Transform my-cases.tsx into tile grid with clickable cards
- Create case-detail.tsx screen showing image, notes, physician info
- Create VisibilityToggle component, integrate on compare screen
- Alembic migration for new columns